### PR TITLE
FIX: 게시글 및 댓글 삭제 알림 관련 오류 해결

### DIFF
--- a/src/main/java/petPeople/pet/controller/post/PostController.java
+++ b/src/main/java/petPeople/pet/controller/post/PostController.java
@@ -82,7 +82,7 @@ public class PostController {
                 .body(respDto);
     }
 
-    @ApiOperation(value = "게시글 좋아요 조회 API", notes = "header 에 토큰을 입력해주세요, 게시글 좋아요 할 postId 를 경로변수에 넣어주세요")
+    @ApiOperation(value = "게시글 좋아요 API", notes = "header 에 토큰을 입력해주세요, 게시글 좋아요 할 postId 를 경로변수에 넣어주세요")
     @PatchMapping("/{postId}")
     public ResponseEntity<Long> likePost(Authentication authentication,
                                          @ApiParam(value = "게시글 ID", required = true) @PathVariable Long postId) {

--- a/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepository.java
@@ -12,6 +12,8 @@ public interface CommentCustomRepository {
 
     Slice<Comment> findAllByIdWithFetchJoinMemberPaging(Long postId, Pageable pageable);
     List<Comment> findByPostIds(List<Long> ids);
+
+    List<Comment> findByPostId(Long postId);
     Long countByPostId(Long postId);
 
     void deleteCommentByPostId(Long postId);

--- a/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepository.java
@@ -13,4 +13,6 @@ public interface CommentCustomRepository {
     Slice<Comment> findAllByIdWithFetchJoinMemberPaging(Long postId, Pageable pageable);
     List<Comment> findByPostIds(List<Long> ids);
     Long countByPostId(Long postId);
+
+    void deleteCommentByPostId(Long postId);
 }

--- a/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -51,6 +51,14 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
     }
 
     @Override
+    public List<Comment> findByPostId(Long postId) {
+        return queryFactory
+                .selectFrom(comment)
+                .where(comment.post.id.eq(postId))
+                .fetch();
+    }
+
+    @Override
     public Long countByPostId(Long postId) {
         return queryFactory
                 .select(comment.count())

--- a/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/petPeople/pet/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -11,6 +11,7 @@ import petPeople.pet.domain.comment.entity.Comment;
 import petPeople.pet.domain.comment.entity.QComment;
 import petPeople.pet.domain.member.entity.QMember;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 
 import static petPeople.pet.domain.comment.entity.QComment.*;
@@ -20,6 +21,7 @@ import static petPeople.pet.domain.member.entity.QMember.*;
 public class CommentCustomRepositoryImpl implements CommentCustomRepository{
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
     @Override
     public Slice<Comment> findAllByIdWithFetchJoinMemberPaging(Long postId, Pageable pageable) {
@@ -55,5 +57,16 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
                 .from(comment)
                 .where(comment.post.id.eq(postId))
                 .fetchOne();
+    }
+
+    @Override
+    public void deleteCommentByPostId(Long postId) {
+        queryFactory
+                .delete(comment)
+                .where(comment.post.id.eq(postId))
+                .execute();
+
+        em.flush();
+        em.clear();
     }
 }

--- a/src/main/java/petPeople/pet/domain/comment/service/CommentService.java
+++ b/src/main/java/petPeople/pet/domain/comment/service/CommentService.java
@@ -113,7 +113,7 @@ public class CommentService {
             deleteCommentLikeByCommentIdAndMemberId(member, commentId);
         } else {
             savePostLike(member, commentId);
-            saveNotification(member, commentId, findComment, findPost);
+//            saveNotification(member, commentId, findComment, findPost);
         }
         return commentLikeRepository.countByCommentId(commentId);
     }

--- a/src/main/java/petPeople/pet/domain/comment/service/CommentService.java
+++ b/src/main/java/petPeople/pet/domain/comment/service/CommentService.java
@@ -99,6 +99,8 @@ public class CommentService {
         validateAuthorization(member, comment);
 
         deleteCommentLikeByCommentId(commentId);
+        notificationRepository.deleteNotificationByOwnerMemberIdAndCommentId(member.getId(), commentId);
+        notificationRepository.deleteNotificationByMemberIdAndWriteCommentId(member.getId(), commentId);
         deleteCommentByCommentId(commentId);
     }
 
@@ -113,7 +115,7 @@ public class CommentService {
             deleteCommentLikeByCommentIdAndMemberId(member, commentId);
         } else {
             savePostLike(member, commentId);
-//            saveNotification(member, commentId, findComment, findPost);
+            saveNotification(member, commentId, findComment, findPost);
         }
         return commentLikeRepository.countByCommentId(commentId);
     }

--- a/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepository.java
+++ b/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepository.java
@@ -15,6 +15,8 @@ public interface NotificationCustomRepository {
 
     Optional<Notification> findByMemberIdAndPostId(Long id, Long postId);
 
+    void deleteNotificationByMemberIdAndPostId(Long memberId, Long postId);
+
     Optional<Notification> findByMemberIdAndCommentId(Long id, Long postId);
 
     Slice<Notification> findByOwnerMemberId(Pageable pageable, Long memberId);

--- a/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepository.java
+++ b/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepository.java
@@ -17,6 +17,10 @@ public interface NotificationCustomRepository {
 
     void deleteNotificationByMemberIdAndPostId(Long memberId, Long postId);
 
+    void deleteNotificationByOwnerMemberIdAndCommentId(Long memberId, Long commentId);
+
+    void deleteNotificationByMemberIdAndWriteCommentId(Long memberId, Long commentId);
+
     Optional<Notification> findByMemberIdAndCommentId(Long id, Long postId);
 
     Slice<Notification> findByOwnerMemberId(Pageable pageable, Long memberId);

--- a/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -54,6 +54,18 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
     }
 
     @Override
+    public void deleteNotificationByMemberIdAndPostId(Long memberId, Long postId) {
+        queryFactory
+                .delete(notification)
+                .where(notification.ownerMember.id.eq(memberId),
+                        notification.post.id.eq(postId))
+                .execute();
+        em.flush();
+        em.clear();
+    }
+
+
+    @Override
     public Optional<Notification> findByMemberIdAndCommentId(Long memberId, Long commentId) {
         Notification content = queryFactory
                 .selectFrom(notification)

--- a/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/petPeople/pet/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -64,6 +64,28 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
         em.clear();
     }
 
+    @Override
+    public void deleteNotificationByOwnerMemberIdAndCommentId(Long memberId, Long commentId) {
+        queryFactory
+                .delete(notification)
+                .where(notification.ownerMember.id.eq(memberId),
+                        notification.comment.id.eq(commentId))
+                .execute();
+        em.flush();
+        em.clear();
+    }
+
+    @Override
+    public void deleteNotificationByMemberIdAndWriteCommentId(Long memberId, Long commentId) {
+        queryFactory
+                .delete(notification)
+                .where(notification.member.id.eq(memberId),
+                        notification.writeComment.id.eq(commentId))
+                .execute();
+        em.flush();
+        em.clear();
+    }
+
 
     @Override
     public Optional<Notification> findByMemberIdAndCommentId(Long memberId, Long commentId) {

--- a/src/main/java/petPeople/pet/domain/post/service/PostService.java
+++ b/src/main/java/petPeople/pet/domain/post/service/PostService.java
@@ -176,6 +176,8 @@ public class PostService {
         deleteTagByPostId(postId);
         deletePostImageByPostId(postId);
         deletePostLikeByPostId(postId);
+        notificationRepository.deleteNotificationByMemberIdAndPostId(member.getId(), postId);
+        commentRepository.deleteCommentByPostId(postId);
         deletePostByPostId(postId);
     }
 


### PR DESCRIPTION
## 해당 이슈 📎
- #58 
  <br/>

## 개발 사항 🛠

- 댓글 삭제 후 알림도 같이 삭제
- 게시글 삭제 후 알림도 같이 삭제

<br/>

## 리뷰어 참고 사항 🙋‍♀️
<br/>