### PR TITLE
MODIFY 회원 미팅 가입 신청 현황 api 대기중만 보기

### DIFF
--- a/src/main/java/petPeople/pet/controller/post/dto/resp/PostRetrieveRespDto.java
+++ b/src/main/java/petPeople/pet/controller/post/dto/resp/PostRetrieveRespDto.java
@@ -50,7 +50,7 @@ public class PostRetrieveRespDto {
     private String nickname;
 
     @ApiModelProperty(required = true, value = "회원 이미지 url", example = "www.img.url")
-    private String imgUrl;
+    private String memberImgUrl;
 
     @ApiModelProperty(required = true, value = "댓글 개수", example = "1")
     private Long commentCnt;
@@ -96,7 +96,7 @@ public class PostRetrieveRespDto {
         this.isLiked = isLiked;
 
         this.nickname = post.getMember().getNickname();
-        this.imgUrl = post.getMember().getImgUrl();
+        this.memberImgUrl = post.getMember().getImgUrl();
         this.commentCnt = commentCnt;
 
         if (member == null) {

--- a/src/main/java/petPeople/pet/domain/meeting/repository/MeetingWaitingMemberCustomRepositoryImpl.java
+++ b/src/main/java/petPeople/pet/domain/meeting/repository/MeetingWaitingMemberCustomRepositoryImpl.java
@@ -61,7 +61,7 @@ public class MeetingWaitingMemberCustomRepositoryImpl implements MeetingWaitingM
                 .selectFrom(meetingWaitingMember)
                 .join(meetingWaitingMember.member, member).fetchJoin()
                 .join(meetingWaitingMember.meeting, meeting).fetchJoin()
-                .where(meetingWaitingMember.member.id.eq(memberId))
+                .where(meetingWaitingMember.member.id.eq(memberId), meetingWaitingMember.joinRequestStatus.eq(JoinRequestStatus.WAITING))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .orderBy(meetingWaitingMember.createdDate.desc())


### PR DESCRIPTION
## 해당 이슈 📎
- #98 
  <br/>

## 개발 사항 🛠

- 모임 가입 신청 현황 api 조회 시 가입 대기중인 목록만 보기
- 거절, 승인 등은 보이지 않기

<br/>